### PR TITLE
Use the correct URL for metadata fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "license": "MIT",
   "description": "A toolbox for your React Native app localization.",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",
-  "homepage": "https://github.com/react-community/react-native-localize",
+  "homepage": "https://github.com/react-native-community/react-native-localize",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/react-community/react-native-localize.git"
+    "url": "https://github.com/react-native-community/react-native-localize.git"
   },
   "keywords": [
     "react-native-localize",


### PR DESCRIPTION
Hey!

We are using an auto license generator script to include all OSS projects in our app and when checking the URL for react-native-localize we hit a 404 because the URL is incorrect.

I corrected it to point to the correct repo and correct URL field. 👋