### PR TITLE
Fix Incorrect source_files path in Podspec

### DIFF
--- a/ios/RNLocalize.podspec
+++ b/ios/RNLocalize.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = "9.0"
 
   s.source                 = { :git => "#{s.homepage}.git", :tag => s.version }
-  s.source_files           = "*.{h,m}"
+  s.source_files           = "ios/*.{h,m}"
 end


### PR DESCRIPTION
The file glob was set up such that it would look for ios m and h
files in the root directory instead of the ios directory.