### PR TITLE
Observe Timezone change for iOS

### DIFF
--- a/ios/RNLocalize.m
+++ b/ios/RNLocalize.m
@@ -150,6 +150,11 @@ RCT_EXPORT_MODULE();
                                            selector:@selector(onLocalizationDidChange)
                                                name:NSCurrentLocaleDidChangeNotification
                                              object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(onLocalizationDidChange)
+                                               name:NSSystemTimeZoneDidChangeNotification
+                                             object:nil];
+
 }
 
 - (void)stopObserving {


### PR DESCRIPTION
At the moment, the library is able to send an event when the timezone is changed on Android. However, it does not work for iOS. 
The reason for this is that iOS is using NSSystemTimeZoneDidChangeNotification for timezone related changes.