### PR TITLE
Upgrade react-native to 0.59.5

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "i18n-js": "^3.2.1",
     "lodash.memoize": "^4.1.2",
     "react": "16.8.3",
-    "react-native": "0.59.3",
+    "react-native": "0.59.5",
     "react-native-fs": "^2.13.3",
     "react-native-localize": "file:../"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5061,12 +5061,12 @@ react-native-fs@^2.13.3:
     utf8 "^2.1.1"
 
 "react-native-localize@file:..":
-  version "1.1.1"
+  version "1.1.2"
 
-react-native@0.59.3:
-  version "0.59.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.3.tgz#b984bbe457f63d5515046d32ea5721fd22843548"
-  integrity sha512-dv3AA2rH0L0IccxRkIs4YsriaECy9ttTXrwrgwETXqmE45uVrBFRGePUFnqjcikYkkm6sS0FRxcva088un76JA==
+react-native@0.59.5:
+  version "0.59.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.5.tgz#79500d2885a3dc83216715e1fc6effa878ad6ea9"
+  integrity sha512-8Q/9cS6IMsGNiFhJgzmncbUeuacXQMe5EJl0c63fW30DvjEjeTVCvhM08eGzSpsNlOvL2XDRa4YOiCrwI7S1TA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^1.2.1"


### PR DESCRIPTION
This updates the `react-native` dependency in the `example` project from `0.59.3` to `0.59.5`.