### PR TITLE
Fix uncaught exception for web platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 // @flow
 
-import React from "react";
-import { NativeModules, NativeEventEmitter } from "react-native";
+import { Platform, NativeModules, NativeEventEmitter } from "react-native";
 let { RNLocalize } = NativeModules;
 if (Platform.OS === 'web' || Platform.OS === 'dom') {
   RNLocalize = require('./web');

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@
 
 import React from "react";
 import { NativeModules, NativeEventEmitter } from "react-native";
-const { RNLocalize } = NativeModules;
+let { RNLocalize } = NativeModules;
+if (Platform.OS === 'web' || Platform.OS === 'dom') {
+  RNLocalize = require('./web');
+}
+if (!RNLocalize) {
+  throw new Error('@react-native-localize: NativeModule.RNLocalize is null.');
+}
 
 export type Option<T> = T | boolean;
 

--- a/web/index.js
+++ b/web/index.js
@@ -1,0 +1,4 @@
+module.exports = { 
+  initialConstants: {
+  }
+}


### PR DESCRIPTION
# Summary

Using react-native-localize on a react-native-web platform, or any platform that does not have a RNLocalize native module implementation, results in an exception being thrown.
A platform check resolves this. The actual native web component is a stub for now.

An extra check for the existence of RNLocalize makes sure a meaningful error is thrown on any other platforms if it is not available.

## Test Plan

Querying any RNLocalize method will return `undefined`, but does not throw an exception.
```
import * as RNLocalize from 'react-native-localize';
const locales = RNLocalize.getLocales();
const calendar = RNLocalize.getCalendar();
// ...
```
No changes on existing supported platform.

### What's required for testing (prerequisites)?

Create a react-native-web app.

### What are the steps to reproduce (after prerequisites)?

```
import * as RNLocalize from 'react-native-localize';
const locales = RNLocalize.getLocales();
// exception is thrown: Uncaught TypeError: Cannot read property 'initialConstants' of undefined
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| web |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
