### PR TITLE
Add support for react-native-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ public class MainApplication extends Application implements ReactApplication {
 }
 ```
 
+## React Native Web
+
+Support for react-native-web can be enabled by adding the following to your webpack
+config:
+
+```js
+resolver: {
+  resolverMainFields: ["react-native-web", "react-native", "browser", "main"],
+}
+```
+
 ## Basic usage example
 
 ```js

--- a/index.web.js
+++ b/index.web.js
@@ -44,7 +44,7 @@ export function getCountry(): string {
   return locales[0] && locales[0].countryCode;
 }
 export function getCurrencies(): string[] {
-  return LocaleCurrency.getCurrency(getCountry());
+  return [LocaleCurrency.getCurrency(getCountry())];
 }
 export function getLocales(): Locale[] {
   return navigator.languages.map(languageTag => {

--- a/index.web.js
+++ b/index.web.js
@@ -73,7 +73,7 @@ export function getTemperatureUnit(): TemperatureUnit {
     : "celsius";
 }
 export function getTimeZone(): string {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC";
 }
 export function uses24HourClock(): boolean {
   const date = new Date(Date.UTC(2012, 11, 12, 3, 0, 0));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",
   "homepage": "https://github.com/react-native-community/react-native-localize",
   "main": "index.js",
+  "react-native-web": "index.web.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/react-native-localize.git"
@@ -39,5 +40,9 @@
     "prettier": "1.18.2",
     "react": "16.8.6",
     "react-native": "0.60.5"
+  },
+  "dependencies": {
+    "locale-currency": "^0.0.2",
+    "rtl-detect": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "locale-currency": "^0.0.2",
-    "rtl-detect": "^1.0.2"
+    "bcp-47": "1.0.5"
   }
 }

--- a/types.js
+++ b/types.js
@@ -1,0 +1,33 @@
+// @flow
+export type Option<T> = T | boolean;
+
+export type Calendar = "gregorian" | "japanese" | "buddhist";
+export type LocalizationEvent = "change";
+export type TemperatureUnit = "celsius" | "fahrenheit";
+
+export type Locale = {|
+  +languageCode: string,
+  +scriptCode?: string,
+  +countryCode: string,
+  +languageTag: string,
+  +isRTL: boolean,
+|};
+
+export type NumberFormatSettings = {|
+  +decimalSeparator: string,
+  +groupingSeparator: string,
+|};
+
+export type LocalizationConstants = {|
+  calendar: Calendar,
+  country: string,
+  currencies: string[],
+  locales: Locale[],
+  numberFormatSettings: NumberFormatSettings,
+  temperatureUnit: TemperatureUnit,
+  timeZone: string,
+  uses24HourClock: boolean,
+  usesMetricSystem: boolean,
+  usesAutoDateAndTime: Option<boolean>,
+  usesAutoTimeZone: Option<boolean>,
+|};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,6 +2942,11 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+locale-currency@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/locale-currency/-/locale-currency-0.0.2.tgz#e2c90607563ce47a59f9559e45a70e24e4db4b6d"
+  integrity sha1-4skGB1Y85HpZ+VWeRacOJOTbS20=
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -4361,6 +4366,11 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+rtl-detect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rtl-detect/-/rtl-detect-1.0.2.tgz#8eca316f5c6563d54df4e406171dd7819adda67f"
+  integrity sha512-5X1422hvphzg2a/bo4tIDbjFjbJUOaPZwqE6dnyyxqwFqfR+tBcvfqapJr0o0VygATVCGKiODEewhZtKF+90AA==
 
 run-async@^2.2.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,6 +1201,15 @@ basic-auth@~2.0.0:
   dependencies:
     safe-buffer "5.1.2"
 
+bcp-47@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/bcp-47/-/bcp-47-1.0.5.tgz#9cb5e53c3d03e09f7d20f5f0affda1cde296a64f"
+  integrity sha512-BiuU8i9Rp2ssV8Tsh/h/+Dkdh2M38gKxP90p1VXf079YHqg4Iye58W+CO2OUy36yXbUVC747rypATdRsCtKneA==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+
 big-integer@^1.6.7:
   version "1.6.45"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.45.tgz#1bf2fa1271bfd20d4c52c3d6c6f08cab8d91c77e"
@@ -2474,6 +2483,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.3.tgz#eb04cc47219a8895d8450ace4715abff2258a1f8"
+  integrity sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz#57ae21c374277b3defe0274c640a5704b8f6657c"
+  integrity sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -2503,6 +2525,11 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-decimal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.3.tgz#381068759b9dc807d8c0dc0bfbae2b68e1da48b7"
+  integrity sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4366,11 +4393,6 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
-
-rtl-detect@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/rtl-detect/-/rtl-detect-1.0.2.tgz#8eca316f5c6563d54df4e406171dd7819adda67f"
-  integrity sha512-5X1422hvphzg2a/bo4tIDbjFjbJUOaPZwqE6dnyyxqwFqfR+tBcvfqapJr0o0VygATVCGKiODEewhZtKF+90AA==
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
# Summary
Add support for react-native-web. Moving from RN device info, which had web support, broke our apps.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
