### PR TITLE
fix: `findBestAvailableLanguage` should not return `void` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,5 +42,5 @@ declare module "react-native-localize" {
 
   export function findBestAvailableLanguage<T extends string>(
     languageTags: T[],
-  ): { languageTag: T; isRTL: boolean } | void;
+  ): { languageTag: T; isRTL: boolean } | undefined;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export function findBestAvailableLanguage(
 ): {|
   languageTag: string,
   isRTL: boolean,
-|} | void {
+|} | undefined {
   const locales = getLocales();
 
   for (let i = 0; i < locales.length; i++) {


### PR DESCRIPTION
fixes https://github.com/react-native-community/react-native-localize/issues/92


# Summary

i fixed the type error which breaks optional chaining

## Test Plan

no plan sorry

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` 
- [ ] I mentioned this change in `CHANGELOG.md` ( i guess that is automatic ?)
- [ ] I updated the typed files (TS and Flow) (not sure if i did right)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
